### PR TITLE
Desgin: 카테고리/아이템 리스트 페이지 레이아웃 수정

### DIFF
--- a/src/main/java/com/example/team1/Prometheus/controller/CategoryController.java
+++ b/src/main/java/com/example/team1/Prometheus/controller/CategoryController.java
@@ -1,16 +1,15 @@
 package com.example.team1.Prometheus.controller;
 
-import com.example.team1.Prometheus.entity.CategoryRequest;
-import com.example.team1.Prometheus.entity.CategoryResponse;
+import com.example.team1.Prometheus.entity.*;
 import com.example.team1.Prometheus.service.CategoryService;
 import com.example.team1.Prometheus.service.UserService;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import java.util.List;
 
@@ -45,20 +44,49 @@ public class CategoryController {
 
     @PostMapping("/new")
     public String createCategory(@ModelAttribute("categoryRequest") CategoryRequest categoryRequest,
-                                 HttpServletRequest httpServletRequest){
+                                 RedirectAttributes redirectAttributes,
+                                 HttpServletRequest httpServletRequest) {
+
         CategoryResponse category = categoryService.createCategory(categoryRequest, httpServletRequest);
         log.info("\n\n등록할 카테고리 확인: {}\n\n", category);
 
+        redirectAttributes.addFlashAttribute("success", "등록되었습니다.");
         return "redirect:/categories";
     }
 
-    @PutMapping()
-    public String updateCategory() {
-        return "";
+    @GetMapping("/{id}")
+    public String updateCategory(@PathVariable("id") Long id, Model model,
+                                 HttpServletRequest httpServletRequest) {
+
+        CategoryResponse category = categoryService.findById(id, httpServletRequest);
+
+        model.addAttribute("category", category);
+
+        return "category/edit";
+    }
+
+    @PostMapping("/{id}")
+    public String updateCategory(@PathVariable("id") Long id,
+                                 CategoryRequest request,
+                                 RedirectAttributes redirectAttributes,
+                                 HttpServletRequest httpServletRequest) {
+
+        CategoryResponse res = categoryService.updateItem(id, request, httpServletRequest);
+        log.info("\n\n상품 수정 확인: {}\n\n", res);
+
+        redirectAttributes.addFlashAttribute("success", "수정되었습니다.");
+        return "redirect:/categories";
     }
 
     @DeleteMapping()
-    public String deleteCategory() {
-        return "";
+    public String deleteCategory(@RequestParam("categoryId") Long id,
+                                 RedirectAttributes redirectAttributes,
+                                 HttpServletRequest httpServletRequest) {
+
+        CategoryResponse res = categoryService.deleteItem(id, httpServletRequest);
+        log.info("\n\n상품 삭제 확인: {}\n\n", res);
+
+        redirectAttributes.addFlashAttribute("success", "삭제되었습니다.");
+        return "redirect:/categories";
     }
 }

--- a/src/main/java/com/example/team1/Prometheus/exception/NotFoundCategoryById.java
+++ b/src/main/java/com/example/team1/Prometheus/exception/NotFoundCategoryById.java
@@ -1,0 +1,7 @@
+package com.example.team1.Prometheus.exception;
+
+public class NotFoundCategoryById extends IllegalArgumentException{
+    public NotFoundCategoryById(Long id) {
+        super("\'카테고리 ID " + id + "\' 은 존재하지 않습니다.");
+    }
+}

--- a/src/main/java/com/example/team1/Prometheus/service/CategoryService.java
+++ b/src/main/java/com/example/team1/Prometheus/service/CategoryService.java
@@ -1,10 +1,7 @@
 package com.example.team1.Prometheus.service;
 
-import com.example.team1.Prometheus.entity.Category;
-import com.example.team1.Prometheus.entity.CategoryRequest;
-import com.example.team1.Prometheus.entity.CategoryResponse;
-import com.example.team1.Prometheus.exception.NotFoundItemById;
-import com.example.team1.Prometheus.exception.UnauthorizedCreateByUser;
+import com.example.team1.Prometheus.entity.*;
+import com.example.team1.Prometheus.exception.*;
 import com.example.team1.Prometheus.mapper.CategoryMapper;
 import com.example.team1.Prometheus.repository.CategoryRepository;
 import jakarta.servlet.http.HttpServletRequest;
@@ -28,7 +25,9 @@ public class CategoryService {
 
     @Transactional
     public List<CategoryResponse> getAll() {
+
         List<Category> categories = categoryRepository.findAll();
+
         return categories.stream()
                 .map(categoryMapper::toResponse)
                 .collect(Collectors.toList());
@@ -47,5 +46,59 @@ public class CategoryService {
         Category savedCategory = categoryRepository.save(category);
 
         return categoryMapper.toResponse(savedCategory);
+    }
+
+    @Transactional
+    public CategoryResponse findById(Long id, HttpServletRequest httpServletRequest) {
+        Category category = categoryRepository.findById(id)
+                .orElseThrow(() -> new NotFoundCategoryById(id));
+
+        String userName = userService.getSessionUser(httpServletRequest).getUserName();
+
+        if(!userName.equals("admin")) {
+            throw new UnauthorizedModifyByUser(userName);
+        }
+
+        return categoryMapper.toResponse(category);
+    }
+
+    @Transactional
+    public CategoryResponse updateItem(Long id, CategoryRequest request, HttpServletRequest httpServletRequest) {
+
+        Category category = categoryRepository.findById(id)
+                .orElseThrow(() -> new NotFoundCategoryById(id));
+
+        String userName = userService.getSessionUser(httpServletRequest).getUserName();
+
+        if (!userName.equals("admin")) {
+            throw new UnauthorizedDeleteByUser(userName);
+        }
+
+        Category updatedCategory = Category.builder()
+                .categoryId(category.getCategoryId())
+                .name(request.getName())
+                .createdAt(category.getCreatedAt())
+                .build();
+
+        Category savedCategory = categoryRepository.save(updatedCategory);
+
+        return categoryMapper.toResponse(savedCategory);
+    }
+
+    @Transactional
+    public CategoryResponse deleteItem(Long id, HttpServletRequest httpServletRequest) {
+
+        Category category = categoryRepository.findById(id)
+                .orElseThrow(() -> new NotFoundCategoryById(id));
+
+        String userName = userService.getSessionUser(httpServletRequest).getUserName();
+
+        if (!userName.equals("admin")) {
+            throw new UnauthorizedDeleteByUser(userName);
+        }
+
+        categoryRepository.deleteById(id);
+
+        return categoryMapper.toResponse(category);
     }
 }

--- a/src/main/resources/templates/category/categories.html
+++ b/src/main/resources/templates/category/categories.html
@@ -8,30 +8,53 @@
 <body>
 <main class="container mx-auto px-4 max-w-3xl rounded-lg overflow-hidden p-2 flex justify-center items-center">
     <div>
-        <h2 class="px-4 py-2 text-2xl font-semibold"> Categories </h2>
+        <h2 class="px-4 py-2 text-2xl font-semibold"> 카테고리 </h2>
     </div>
 
 </main>
 <main>
+    <!--    수정/삭제 후 메시지 출력    -->
+    <div id="success" th:data-value="${success}"></div>
+    <div id="error" th:data-value="${error}"></div>
     <ul class="bg-slate-50 mx-auto max-w-5xl p-4 sm:px-8 sm:pt-6 sm:pb-8 lg:p-4 xl:px-8 xl:pt-6 xl:pb-8 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-1 xl:grid-cols-2 gap-10 text-sm leading-6  justify-center items-center">
-        <li class="flex" th:each="category : ${categories}">
-            <div class="h-auto  w-full rounded-md bg-gradient-to-r from-blue-300 to-purple-300 hover:from-blue-400 hover:to-purple-400 text-white font-semibold py-1 px-1 rounded-md transition duration-300 transform hover:scale-105 ease-in-out flex items-center shadow-lg p-1">
+        <li class="relative mb-4 flex items-start" th:each="category : ${categories}">
+            <div th:if="${userName == 'admin'}">
+            <div class="absolute top-2 right-2 flex space-x-2 z-10">
+                <!-- 수정 버튼 -->
+                <a th:href="@{/categories/{id}(id=${category.categoryId})}"
+                   class="flex items-center justify-center p-2 bg-transparent hover:bg-gray-200 text-gray-500 hover:text-gray-600 font-semibold rounded-lg transition duration-300 transform hover:scale-105 ease-in-out border border-gray-500 shadow-sm">
+                    <i data-feather="edit" class="w-3 h-3"></i>
+                </a>
+
+                <!-- 삭제 버튼 -->
+                <form th:action="@{/categories}" th:method="delete" onsubmit="return confirm('삭제 하시겠습니까?');">
+                    <input type="hidden" name="categoryId" th:value="${category.categoryId}">
+                    <button type="submit"
+                            class="flex items-center justify-center p-2 bg-transparent hover:bg-gray-200 text-gray-500 hover:text-gray-600 font-semibold rounded-lg transition duration-300 transform hover:scale-105 ease-in-out border border-gray-500 shadow-sm">
+                        <i data-feather="trash" class="w-3 h-3"></i>
+                    </button>
+                </form>
+            </div>
+            </div>
+
+            <!-- 카테고리 정보 표시 -->
+            <div class="h-auto w-full rounded-md bg-gradient-to-r from-blue-300 to-purple-300 hover:from-blue-400 hover:to-purple-400 text-white py-1 px-1  transition duration-300 transform hover:scale-105 ease-in-out flex items-center shadow-lg p-1">
                 <a th:href="@{/items}"
-                   class="bg-white group w-full flex flex-col items-center justify-center rounded-md border-1  border-slate-0 text-sm leading-6 text-slate-900 font-big py-2">
-                <div th:text="${category.categoryId}"></div>
-                <div th:text="${category.name}"></div>
-            </a>
+                   class="bg-white group w-full flex flex-col items-center justify-center rounded-md border border-slate-0 text-base leading-6 text-slate-900 font-big py-5">
+                    <div th:text="${category.name}"></div>
+                </a>
             </div>
         </li>
+
         <div th:if="${userName == 'admin'}">
-            <li class="flex">
-                <div class="h-auto  w-full rounded-md bg-gradient-to-r from-blue-0 to-purple-0 hover:from-blue-400 hover:to-purple-400 text-white font-semibold py-1 px-1 rounded-md transition duration-300 transform hover:scale-105 ease-in-out flex items-center shadow-lg p-1">
+            <li class="relative mb-4 flex items-start">
+                <div class="h-auto  w-full rounded-md bg-gradient-to-r from-blue-0 to-purple-0 hover:from-blue-400 hover:to-purple-400 text-white  py-1 px-1 rounded-md transition duration-300 transform hover:scale-105 ease-in-out flex items-center shadow-lg p-1">
                     <a th:href="@{/categories/new}"
-                       class="bg-white group w-full flex flex-col items-center justify-center rounded-md border-1  border-slate-0 text-sm leading-6 text-slate-900 font-big py-2">
-                    <svg class="group-hover:text-blue-500 mb-1 text-slate-400" width="20" height="20" fill="currentColor" aria-hidden="true">
+                       class="bg-white group w-full flex flex-row items-center justify-center rounded-md border-1  border-slate-0 text-base leading-6 text-slate-900 font-big py-5">
+                    <svg class="group-hover:text-blue-500 mb-0 mr-2 text-slate-400" width="20" height="20" fill="currentColor" aria-hidden="true">
                             <path d="M10 5a1 1 0 0 1 1 1v3h3a1 1 0 1 1 0 2h-3v3a1 1 0 1 1-2 0v-3H6a1 1 0 1 1 0-2h3V6a1 1 0 0 1 1-1Z" />
                         </svg>
-                        New Category
+                        새 카테고리
                     </a>
                 </div>
             </li>

--- a/src/main/resources/templates/category/edit.html
+++ b/src/main/resources/templates/category/edit.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      th:replace="~{fragments/layout :: layout(~{::title}, ~{::main})}">
+<head>
+    <meta charset="UTF-8">
+    <title>카테고리 생성</title>
+</head>
+<body>
+<main>
+    <div class="container mx-auto my-4 px-4 max-w-3xl">
+
+        <button type="button">
+            <a th:href="@{/categories}"
+               class="my-4 bg-gradient-to-r from-blue-400 to-purple-500 hover:from-blue-600 hover:to-purple-600 text-white font-semibold py-2 px-6 rounded-lg transition duration-300 transform hover:scale-105 ease-in-out flex items-center shadow-lg">
+                <i data-feather="arrow-left" class="mr-2"></i>  뒤로가기
+            </a>
+        </button>
+    </div>
+
+    <div class="container mx-auto my-4 px-4 max-w-3xl bg-white shadow-2xl rounded-lg overflow-hidden p-8 flex justify-center items-center transform hover:scale-100 transition duration-300">
+        <form method="post" th:action="@{/categories/{id}(id=${category.categoryId})}">
+            <label for="name"></label>
+            <input type="text" name="name" id="name" th:value="${category.name}"
+                                             class="px-4 py-3 text-2xl font-semibold border-b-2 border-purple-100 focus:border-purple-500 transition duration-300 bg-transparent focus:outline-none"
+                                             placeholder="새로운 카테고리를 입력하세요">
+            <br>
+            <div class="container ustify-end items-right">
+                <button type="submit"
+                        onclick="return confirm('수정 하시겠습니까?');"
+                        class="my-2 bg-gradient-to-r from-blue-400 to-purple-500 hover:from-blue-600 hover:to-purple-600 text-white font-semibold py-2 px-6 rounded-lg transition duration-300 transform hover:scale-105 ease-in-out flex items-center shadow-lg">
+                    <i data-feather="edit-3" class="mr-2"></i>카테고리 수정하기
+                </button>
+            </div>
+        </form>
+    </div>
+</main>
+</body>
+</html>


### PR DESCRIPTION
In GitLab by @silverzoo on Aug 28, 2024, 19:53

### Desgin: 카테고리/아이템 리스트 페이지 레이아웃 수정

* [x] 카테고리 페이지에 있던 검색창 아이템 페이지로 이동
* [x] 카테고리 등록 페이지 일단 생성